### PR TITLE
Change config to have a .json extension

### DIFF
--- a/config.go
+++ b/config.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 )
@@ -15,7 +16,7 @@ type Config struct {
 }
 
 func loadConfig(id string) (*Config, error) {
-	f, err := os.Open(filepath.Join("/etc/containerd-proxy", id))
+	f, err := os.Open(filepath.Join("/etc/containerd-proxy", fmt.Sprintf("%s.json", id)))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Should make it easier to distinguish from the binary file at a glance.

Configurations should look like:
```
/etc/containerd-proxy/dockerd.json
```

cc @crosbymichael @dhiltgen

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>