### PR TITLE
Add post stop command for cleanup

### DIFF
--- a/cleanup.go
+++ b/cleanup.go
@@ -2,27 +2,66 @@ package main
 
 import (
 	"context"
-	"errors"
+	"fmt"
+	"os"
+	"time"
 
 	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/defaults"
 	"github.com/containerd/containerd/errdefs"
+	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
 )
 
-func cleanup(ctx context.Context, container containerd.Container) error {
+func cleanup(ctx context.Context, id string) error {
+	client, err := containerd.New(
+		defaults.DefaultAddress,
+		containerd.WithDefaultRuntime("io.containerd.process.v1"),
+	)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(ctx, 20*time.Second)
+	defer cancel()
+
+	container, err := client.LoadContainer(ctx, id)
+	if err != nil {
+		if !errdefs.IsNotFound(err) {
+			return err
+		}
+		// container does not exist so there is nothing for us to do
+		return nil
+	}
 	task, err := container.Task(ctx, nil)
 	if err != nil {
+		if errdefs.IsNotFound(err) {
+			// there is no running task, nothing to kill
+			return nil
+		}
+		return err
+	}
+	wait, err := task.Wait(ctx)
+	if err != nil {
+		task.Kill(ctx, unix.SIGKILL)
+		_, err = task.Delete(ctx)
+		return err
+	}
+	if err := task.Kill(ctx, unix.SIGKILL); err != nil {
+		fmt.Fprintf(os.Stderr, err.Error())
+	}
+	<-wait
+	_, err = task.Delete(ctx)
+	return err
+}
+
+func checkRunning(ctx context.Context, container containerd.Container) error {
+	if _, err := container.Task(ctx, nil); err != nil {
 		if errdefs.IsNotFound(err) {
 			return nil
 		}
 		return err
 	}
-	status, err := task.Status(ctx)
-	if err != nil {
-		return err
-	}
-	if status.Status != containerd.Stopped {
-		return errors.New("unable to start running container")
-	}
-	_, err = task.Delete(ctx)
-	return err
+	return errors.Errorf("container %s already has a running process", container.ID())
 }

--- a/config.go
+++ b/config.go
@@ -45,18 +45,13 @@ type Config struct {
 // ShouldUpgrade matches the scope and image for a container to decide if an upgrade is required
 func (c *Config) ShouldUpgrade(containerImage, containerScope string) bool {
 	if c.Image != containerImage {
-		switch {
-		case containerScope == "":
-			return true
-		case containerScope == AnyScope:
-			return true
-		case c.Scope == AnyScope:
-			return true
-		case containerScope == c.Scope:
-			return true
-		default:
+		if containerScope == AnyScope && c.Scope != containerScope {
 			return false
 		}
+		if containerScope == "" {
+			return true
+		}
+		return c.Scope == AnyScope
 	}
 	return false
 }

--- a/config_test.go
+++ b/config_test.go
@@ -31,8 +31,8 @@ var upgrades = []struct {
 			Image: "ee02",
 			Scope: AnyScope,
 		},
-		ContainerScope: "ee",
-		ContainerImage: "ee03",
+		ContainerScope: AnyScope,
+		ContainerImage: "ee01",
 		Upgrade:        true,
 	},
 	{
@@ -40,16 +40,7 @@ var upgrades = []struct {
 			Image: "ee02",
 			Scope: AnyScope,
 		},
-		ContainerScope: "ee",
-		ContainerImage: "ee02",
-		Upgrade:        false,
-	},
-	{
-		Config: Config{
-			Image: "ce01",
-			Scope: "ce",
-		},
-		ContainerScope: "ee",
+		ContainerScope: AnyScope,
 		ContainerImage: "ee02",
 		Upgrade:        false,
 	},
@@ -60,7 +51,7 @@ var upgrades = []struct {
 		},
 		ContainerScope: AnyScope,
 		ContainerImage: "ee02",
-		Upgrade:        true,
+		Upgrade:        false,
 	},
 }
 


### PR DESCRIPTION
For use in the unit file like

`ExecStopPost=/usr/local/bin/dockerd post-stop`

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>