### PR TITLE
Add case where the containerScope equal to config

### DIFF
--- a/config.go
+++ b/config.go
@@ -45,6 +45,9 @@ type Config struct {
 // ShouldUpgrade matches the scope and image for a container to decide if an upgrade is required
 func (c *Config) ShouldUpgrade(containerImage, containerScope string) bool {
 	if c.Image != containerImage {
+		if containerScope == c.Scope {
+			return true
+		}
 		if containerScope == AnyScope && c.Scope != containerScope {
 			return false
 		}

--- a/config_test.go
+++ b/config_test.go
@@ -53,6 +53,15 @@ var upgrades = []struct {
 		ContainerImage: "ee02",
 		Upgrade:        false,
 	},
+	{
+		Config: Config{
+			Image: "ce01",
+			Scope: "ce",
+		},
+		ContainerScope: "ce",
+		ContainerImage: "ce02",
+		Upgrade:        true,
+	},
 }
 
 func TestUpgrades(t *testing.T) {


### PR DESCRIPTION
Should handle scenarios where the container and the config scope are in
sync and and upgrade should be had

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>